### PR TITLE
Add check if deployment has context-params

### DIFF
--- a/subsystem/src/main/java/com/github/jamesnetherton/extension/liquibase/deployment/LiquibaseChangeLogParseProcessor.java
+++ b/subsystem/src/main/java/com/github/jamesnetherton/extension/liquibase/deployment/LiquibaseChangeLogParseProcessor.java
@@ -75,7 +75,7 @@ public class LiquibaseChangeLogParseProcessor implements DeploymentUnitProcessor
         WarMetaData warMetaData = deploymentUnit.getAttachment(WarMetaData.ATTACHMENT_KEY);
         if (warMetaData != null) {
             WebMetaData webMetaData = warMetaData.getWebMetaData();
-            if (webMetaData != null) {
+            if (webMetaData != null && webMetaData.getContextParams() != null) {
                 changeLogContextParam = webMetaData.getContextParams()
                     .stream()
                     .filter(paramValueMetaData -> paramValueMetaData.getParamName().equals("liquibase.changelog"))


### PR DESCRIPTION
Prevents a NPE on startup, if a deployment doesnt have context-params.

Signed-off-by: Yannick Bröker <ybroeker@techfak.uni-bielefeld.de>